### PR TITLE
feat(apm): inject datadog annotations

### DIFF
--- a/ndustrial/common/Chart.yaml
+++ b/ndustrial/common/Chart.yaml
@@ -19,5 +19,5 @@ sources:
   - https://ndustrial.io/
 type: library
 # Please make sure that version and appVersion are always the same.
-version: 0.2.4
-appVersion: 0.2.4
+version: 0.2.5
+appVersion: 0.2.5

--- a/ndustrial/common/templates/_datadog.tpl
+++ b/ndustrial/common/templates/_datadog.tpl
@@ -22,19 +22,27 @@ Datadog env variables
     fieldRef:
       fieldPath: status.hostIP
 {{- end }}
+- name: DD_SERVICE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.labels['tags.datadoghq.com/service']
 {{- if .value.apm.env }}
 - name: DD_ENV
   value: {{ .value.apm.env }}
 {{- else }}
 - name: DD_ENV
-  value: {{ .context.Values.ndustrial.env | toString | quote }}
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.labels['tags.datadoghq.com/env']
 {{- end }}
 {{- if .value.apm.version }}
 - name: DD_VERSION
   value: {{ .value.apm.version }}
 {{- else }}
 - name: DD_VERSION
-  value: {{ .context.Values.ndustrial.version | toString | quote }}
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.labels['tags.datadoghq.com/version']
 {{- end }}
 - name: DD_PROFILING_ENABLED
   value: {{ .value.apm.profiling_enabled | toString | quote }}

--- a/ndustrial/deployment/Chart.lock
+++ b/ndustrial/deployment/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://ndustrialio.github.io/charts
   version: 0.2.4
-digest: sha256:328052f8c762990450170dc6dc9f05f2431b73b40f7521d75c6331fd8d54f257
-generated: "2021-09-30T16:32:55.2450708Z"
+digest: sha256:a2371b9823edc626e8291493884cc57022fc348ed0e117a201b33127b6e53592
+generated: "2022-01-14T11:43:53.528437-05:00"

--- a/ndustrial/deployment/Chart.yaml
+++ b/ndustrial/deployment/Chart.yaml
@@ -5,12 +5,12 @@ type: application
 dependencies:
   - name: common
     repository: https://ndustrialio.github.io/charts
-    version: 0.2.4
+    version: ~0.2.4
     tags:
       - ndustrial-common
 maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.24
-appVersion: 0.1.24
+version: 0.1.25
+appVersion: 0.1.25


### PR DESCRIPTION
This ensures that our datadog pod annotations are also used as apm configuration, see https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#partial-configuration

> These labels cover pod-level Kubernetes CPU, memory, network, and disk metrics, and can be used for injecting DD_ENV, DD_SERVICE, and DD_VERSION into your service’s container through Kubernetes’s downward API.