### PR TITLE
feat: Allow custom secret templates

### DIFF
--- a/examples/deployment/cert-manager.yml
+++ b/examples/deployment/cert-manager.yml
@@ -40,3 +40,21 @@ externalSecrets:
     provider: fake-backend
     storeKind: SecretStore
   - path: staging/iot-api
+  - secret: my-custom-plucked
+    properties:
+      - name: my_key
+        sourceKey: staging/files-api
+        sourceProp: vault_key
+  - secret: my-custom-plucked-template
+    template: |
+      MY_KEY: {{ "{{ .my_key }}" | quote }} 
+      ANOTHER_KEY: {{ printf "{{ .another_key }}/%s" .Values.tenant | quote }} 
+    properties:
+      - name: my_key
+        sourceKey: staging/files-api
+        sourceProp: vault_key
+      - name: another_key
+        sourceKey: staging/iot-api
+        sourceProp: another_vault_key
+        
+tenant: test-tenant

--- a/ndustrial/cronjob/Chart.yaml
+++ b/ndustrial/cronjob/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.24
-appVersion: 0.1.24
+version: 0.1.25
+appVersion: 0.1.25

--- a/ndustrial/cronjob/templates/externalsecrets.yaml
+++ b/ndustrial/cronjob/templates/externalsecrets.yaml
@@ -1,13 +1,17 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{ $path := required "A valid external secret path is required." .path}}
-{{ $secret := default (printf "%s" $path | replace "/" "-" | trunc 63) .secret }}
+{{- if .path }}
+{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- else }}
+{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
+{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $secret }}
+  name: {{ .secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
-    ndustrial.io/component: cronjob
+    ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
     {{- include "nio-common.tplvalues.render" (dict "value" $.Values.labels "context" $) | nindent 4 }}
     {{- end }}
@@ -20,10 +24,25 @@ spec:
     name: {{ default "vault-backend" .provider }}
     kind: {{ default "ClusterSecretStore" .storeKind }}
   target:
-    name: {{ $secret }}
+    name: {{ .secret }}
+    {{- if .template }}
+    template:
+      data: {{- tpl .template $ | nindent 8 -}}
+    {{- end }}
+  {{- if .path }}
   dataFrom:
     - extract:
-        key: {{ $path }}
+        key: {{ .path }}
+  {{- end }}
+  {{- if .properties }}
+  data:
+    {{- range .properties }}
+    - secretKey: {{ .name }}
+      remoteRef:
+        key: {{ .sourceKey }}
+        property: {{ .sourceProp }}
+    {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/ndustrial/cronjob/values.yaml
+++ b/ndustrial/cronjob/values.yaml
@@ -311,4 +311,9 @@ nodeSelector: {}
 ## @param externalSecrets.0.secret [string] Optionally specify the name of the generated secret. Default value derived from path
 ## @param externalSecrets.0.provider [string] Optionally specify the name of the secret store provider. Defaults to "vault-backend"
 ## @param externalSecrets.0.storeKind [string] Optionally specify the kind of secret store. Defaults to "ClusterSecretStore"
+## @param externalSecrets.0.template [string] Optionally specify the template to use.
+## @param externalSecrets.0.properties [object] If not using "path" above, specify specific properties to pull.
+## @param externalSecrets.0.properties.0.name [string] The name of the property that will be embeded into the secret.
+## @param externalSecrets.0.properties.0.sourceKey [string] The source path to the secret.
+## @param externalSecrets.0.properties.0.sourceProp [string] The source property of the secret to load.
 externalSecrets: []

--- a/ndustrial/daemonset/Chart.yaml
+++ b/ndustrial/daemonset/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.1.3
+appVersion: 0.1.3

--- a/ndustrial/daemonset/templates/externalsecrets.yaml
+++ b/ndustrial/daemonset/templates/externalsecrets.yaml
@@ -1,13 +1,17 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{ $path := required "A valid external secret path is required." .path}}
-{{ $secret := default (printf "%s" $path | replace "/" "-" | trunc 63) .secret }}
+{{- if .path }}
+{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- else }}
+{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
+{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $secret }}
+  name: {{ .secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
-    ndustrial.io/component: deployment
+    ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
     {{- include "nio-common.tplvalues.render" (dict "value" $.Values.labels "context" $) | nindent 4 }}
     {{- end }}
@@ -20,10 +24,25 @@ spec:
     name: {{ default "vault-backend" .provider }}
     kind: {{ default "ClusterSecretStore" .storeKind }}
   target:
-    name: {{ $secret }}
+    name: {{ .secret }}
+    {{- if .template }}
+    template:
+      data: {{- tpl .template $ | nindent 8 -}}
+    {{- end }}
+  {{- if .path }}
   dataFrom:
     - extract:
-        key: {{ $path }}
+        key: {{ .path }}
+  {{- end }}
+  {{- if .properties }}
+  data:
+    {{- range .properties }}
+    - secretKey: {{ .name }}
+      remoteRef:
+        key: {{ .sourceKey }}
+        property: {{ .sourceProp }}
+    {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/ndustrial/daemonset/values.yaml
+++ b/ndustrial/daemonset/values.yaml
@@ -559,4 +559,9 @@ datadog:
 ## @param externalSecrets.0.secret [string] Optionally specify the name of the generated secret. Default value derived from path
 ## @param externalSecrets.0.provider [string] Optionally specify the name of the secret store provider. Defaults to "vault-backend"
 ## @param externalSecrets.0.storeKind [string] Optionally specify the kind of secret store. Defaults to "ClusterSecretStore"
+## @param externalSecrets.0.template [string] Optionally specify the template to use.
+## @param externalSecrets.0.properties [object] If not using "path" above, specify specific properties to pull.
+## @param externalSecrets.0.properties.0.name [string] The name of the property that will be embeded into the secret.
+## @param externalSecrets.0.properties.0.sourceKey [string] The source path to the secret.
+## @param externalSecrets.0.properties.0.sourceProp [string] The source property of the secret to load.
 externalSecrets: []

--- a/ndustrial/deployment/Chart.yaml
+++ b/ndustrial/deployment/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.40
-appVersion: 0.1.40
+version: 0.1.41
+appVersion: 0.1.41

--- a/ndustrial/deployment/templates/externalsecrets.yaml
+++ b/ndustrial/deployment/templates/externalsecrets.yaml
@@ -1,13 +1,17 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{ $path := required "A valid external secret path is required." .path}}
-{{ $secret := default (printf "%s" $path | replace "/" "-" | trunc 63) .secret }}
+{{- if .path }}
+{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- else }}
+{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
+{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $secret }}
+  name: {{ .secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
-    ndustrial.io/component: deployment
+    ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
     {{- include "nio-common.tplvalues.render" (dict "value" $.Values.labels "context" $) | nindent 4 }}
     {{- end }}
@@ -20,10 +24,25 @@ spec:
     name: {{ default "vault-backend" .provider }}
     kind: {{ default "ClusterSecretStore" .storeKind }}
   target:
-    name: {{ $secret }}
+    name: {{ .secret }}
+    {{- if .template }}
+    template:
+      data: {{- tpl .template $ | nindent 8 -}}
+    {{- end }}
+  {{- if .path }}
   dataFrom:
     - extract:
-        key: {{ $path }}
+        key: {{ .path }}
+  {{- end }}
+  {{- if .properties }}
+  data:
+    {{- range .properties }}
+    - secretKey: {{ .name }}
+      remoteRef:
+        key: {{ .sourceKey }}
+        property: {{ .sourceProp }}
+    {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/ndustrial/deployment/values.yaml
+++ b/ndustrial/deployment/values.yaml
@@ -578,8 +578,13 @@ datadog:
 ## @section External secrets
 
 ## @param externalSecrets [array] Secrets resolved from an external source
-## @param externalSecrets.0.path [string] Path of the external secret
+## @param externalSecrets.0.path [string] Path of the external secret if pulling all values
 ## @param externalSecrets.0.secret [string] Optionally specify the name of the generated secret. Default value derived from path
 ## @param externalSecrets.0.provider [string] Optionally specify the name of the secret store provider. Defaults to "vault-backend"
 ## @param externalSecrets.0.storeKind [string] Optionally specify the kind of secret store. Defaults to "ClusterSecretStore"
+## @param externalSecrets.0.template [string] Optionally specify the template to use.
+## @param externalSecrets.0.properties [object] If not using "path" above, specify specific properties to pull.
+## @param externalSecrets.0.properties.0.name [string] The name of the property that will be embeded into the secret.
+## @param externalSecrets.0.properties.0.sourceKey [string] The source path to the secret.
+## @param externalSecrets.0.properties.0.sourceProp [string] The source property of the secret to load.
 externalSecrets: []

--- a/ndustrial/nio-api/Chart.yaml
+++ b/ndustrial/nio-api/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4

--- a/ndustrial/nio-api/values.yaml
+++ b/ndustrial/nio-api/values.yaml
@@ -547,4 +547,9 @@ datadog:
 ## @param externalSecrets.0.secret [string] Optionally specify the name of the generated secret. Default value derived from path
 ## @param externalSecrets.0.provider [string] Optionally specify the name of the secret store provider. Defaults to "vault-backend"
 ## @param externalSecrets.0.storeKind [string] Optionally specify the kind of secret store. Defaults to "ClusterSecretStore"
+## @param externalSecrets.0.template [string] Optionally specify the template to use.
+## @param externalSecrets.0.properties [object] If not using "path" above, specify specific properties to pull.
+## @param externalSecrets.0.properties.0.name [string] The name of the property that will be embeded into the secret.
+## @param externalSecrets.0.properties.0.sourceKey [string] The source path to the secret.
+## @param externalSecrets.0.properties.0.sourceProp [string] The source property of the secret to load.
 externalSecrets: []

--- a/ndustrial/statefulset/Chart.yaml
+++ b/ndustrial/statefulset/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.35
-appVersion: 0.1.35
+version: 0.1.36
+appVersion: 0.1.36

--- a/ndustrial/statefulset/templates/externalsecrets.yaml
+++ b/ndustrial/statefulset/templates/externalsecrets.yaml
@@ -1,11 +1,15 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{ $path := required "A valid external secret path is required." .path}}
-{{ $secret := default (printf "%s" $path | replace "/" "-" | trunc 63) .secret }}
+{{- if .path }}
+{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- else }}
+{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
+{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $secret }}
+  name: {{ .secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
     ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
@@ -20,10 +24,25 @@ spec:
     name: {{ default "vault-backend" .provider }}
     kind: {{ default "ClusterSecretStore" .storeKind }}
   target:
-    name: {{ $secret }}
+    name: {{ .secret }}
+    {{- if .template }}
+    template:
+      data: {{- tpl .template $ | nindent 8 -}}
+    {{- end }}
+  {{- if .path }}
   dataFrom:
     - extract:
-        key: {{ $path }}
+        key: {{ .path }}
+  {{- end }}
+  {{- if .properties }}
+  data:
+    {{- range .properties }}
+    - secretKey: {{ .name }}
+      remoteRef:
+        key: {{ .sourceKey }}
+        property: {{ .sourceProp }}
+    {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/ndustrial/statefulset/values.yaml
+++ b/ndustrial/statefulset/values.yaml
@@ -574,4 +574,9 @@ datadog:
 ## @param externalSecrets.0.secret [string] Optionally specify the name of the generated secret. Default value derived from path
 ## @param externalSecrets.0.provider [string] Optionally specify the name of the secret store provider. Defaults to "vault-backend"
 ## @param externalSecrets.0.storeKind [string] Optionally specify the kind of secret store. Defaults to "ClusterSecretStore"
+## @param externalSecrets.0.template [string] Optionally specify the template to use.
+## @param externalSecrets.0.properties [object] If not using "path" above, specify specific properties to pull.
+## @param externalSecrets.0.properties.0.name [string] The name of the property that will be embeded into the secret.
+## @param externalSecrets.0.properties.0.sourceKey [string] The source path to the secret.
+## @param externalSecrets.0.properties.0.sourceProp [string] The source property of the secret to load.
 externalSecrets: []


### PR DESCRIPTION
Allows our charts to support passing custom templates for external secrets (See [Advanced Templating](https://external-secrets.io/v0.6.1/guides/templating/))