### PR TITLE
feat: allow templated secrets

### DIFF
--- a/examples/deployment/cert-manager.yml
+++ b/examples/deployment/cert-manager.yml
@@ -34,6 +34,7 @@ datadog:
   openmetrics:
     enabled: false
 
+templateName: test
 externalSecrets:
   - path: staging/files-api
     secret: my-custom-secret-name
@@ -56,5 +57,12 @@ externalSecrets:
       - name: another_key
         sourceKey: staging/iot-api
         sourceProp: another_vault_key
+  - secret: my-templated-secret-{{ .Values.templateName }}
+    template: |
+      MY_KEY: {{ "{{ .my_key }}" | quote }} 
+    properties:
+      - name: my_key
+        sourceKey: staging/files-api
+        sourceProp: vault_key
         
 tenant: test-tenant

--- a/ndustrial/cronjob/Chart.yaml
+++ b/ndustrial/cronjob/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.26
-appVersion: 0.1.26
+version: 0.1.27
+appVersion: 0.1.27

--- a/ndustrial/cronjob/templates/externalsecrets.yaml
+++ b/ndustrial/cronjob/templates/externalsecrets.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{- if .path }}
-{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- $externalSecret := merge (dict "template" .template) (fromYaml (tpl (toYaml (omit . "template" )) $)) -}}
+{{- if $externalSecret.path }}
+{{- $_ := set $externalSecret "secret" (default (printf "%s" $externalSecret.path | replace "/" "-" | trunc 63) $externalSecret.secret) }}
 {{- else }}
-{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
-{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- $_ := set $externalSecret "secret" (required "A secret is required when not passing path." $externalSecret.secret) }}
+{{- $_ := set $externalSecret "properties" (required "A property list is required when not passing path." $externalSecret.properties) }}
 {{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .secret }}
+  name: {{ $externalSecret.secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
     ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
@@ -21,22 +22,22 @@ metadata:
 spec:
   refreshInterval: "5m"
   secretStoreRef:
-    name: {{ default "vault-backend" .provider }}
-    kind: {{ default "ClusterSecretStore" .storeKind }}
+    name: {{ default "vault-backend" $externalSecret.provider }}
+    kind: {{ default "ClusterSecretStore" $externalSecret.storeKind }}
   target:
-    name: {{ .secret }}
-    {{- if .template }}
+    name: {{ $externalSecret.secret }}
+    {{- if $externalSecret.template }}
     template:
-      data: {{- tpl .template $ | nindent 8 -}}
+      data: {{- tpl $externalSecret.template $ | nindent 8 -}}
     {{- end }}
-  {{- if .path }}
+  {{- if $externalSecret.path }}
   dataFrom:
     - extract:
-        key: {{ .path }}
+        key: {{ $externalSecret.path }}
   {{- end }}
-  {{- if .properties }}
+  {{- if $externalSecret.properties }}
   data:
-    {{- range .properties }}
+    {{- range $externalSecret.properties }}
     - secretKey: {{ .name }}
       remoteRef:
         key: {{ .sourceKey }}

--- a/ndustrial/daemonset/Chart.yaml
+++ b/ndustrial/daemonset/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.4
-appVersion: 0.1.4
+version: 0.1.5
+appVersion: 0.1.5

--- a/ndustrial/daemonset/templates/externalsecrets.yaml
+++ b/ndustrial/daemonset/templates/externalsecrets.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{- if .path }}
-{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- $externalSecret := merge (dict "template" .template) (fromYaml (tpl (toYaml (omit . "template" )) $)) -}}
+{{- if $externalSecret.path }}
+{{- $_ := set $externalSecret "secret" (default (printf "%s" $externalSecret.path | replace "/" "-" | trunc 63) $externalSecret.secret) }}
 {{- else }}
-{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
-{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- $_ := set $externalSecret "secret" (required "A secret is required when not passing path." $externalSecret.secret) }}
+{{- $_ := set $externalSecret "properties" (required "A property list is required when not passing path." $externalSecret.properties) }}
 {{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .secret }}
+  name: {{ $externalSecret.secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
     ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
@@ -21,22 +22,22 @@ metadata:
 spec:
   refreshInterval: "5m"
   secretStoreRef:
-    name: {{ default "vault-backend" .provider }}
-    kind: {{ default "ClusterSecretStore" .storeKind }}
+    name: {{ default "vault-backend" $externalSecret.provider }}
+    kind: {{ default "ClusterSecretStore" $externalSecret.storeKind }}
   target:
-    name: {{ .secret }}
-    {{- if .template }}
+    name: {{ $externalSecret.secret }}
+    {{- if $externalSecret.template }}
     template:
-      data: {{- tpl .template $ | nindent 8 -}}
+      data: {{- tpl $externalSecret.template $ | nindent 8 -}}
     {{- end }}
-  {{- if .path }}
+  {{- if $externalSecret.path }}
   dataFrom:
     - extract:
-        key: {{ .path }}
+        key: {{ $externalSecret.path }}
   {{- end }}
-  {{- if .properties }}
+  {{- if $externalSecret.properties }}
   data:
-    {{- range .properties }}
+    {{- range $externalSecret.properties }}
     - secretKey: {{ .name }}
       remoteRef:
         key: {{ .sourceKey }}

--- a/ndustrial/deployment/Chart.yaml
+++ b/ndustrial/deployment/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.42
-appVersion: 0.1.42
+version: 0.1.43
+appVersion: 0.1.43

--- a/ndustrial/deployment/templates/externalsecrets.yaml
+++ b/ndustrial/deployment/templates/externalsecrets.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{- if .path }}
-{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- $externalSecret := merge (dict "template" .template) (fromYaml (tpl (toYaml (omit . "template" )) $)) -}}
+{{- if $externalSecret.path }}
+{{- $_ := set $externalSecret "secret" (default (printf "%s" $externalSecret.path | replace "/" "-" | trunc 63) $externalSecret.secret) }}
 {{- else }}
-{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
-{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- $_ := set $externalSecret "secret" (required "A secret is required when not passing path." $externalSecret.secret) }}
+{{- $_ := set $externalSecret "properties" (required "A property list is required when not passing path." $externalSecret.properties) }}
 {{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .secret }}
+  name: {{ $externalSecret.secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
     ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
@@ -21,22 +22,22 @@ metadata:
 spec:
   refreshInterval: "5m"
   secretStoreRef:
-    name: {{ default "vault-backend" .provider }}
-    kind: {{ default "ClusterSecretStore" .storeKind }}
+    name: {{ default "vault-backend" $externalSecret.provider }}
+    kind: {{ default "ClusterSecretStore" $externalSecret.storeKind }}
   target:
-    name: {{ .secret }}
-    {{- if .template }}
+    name: {{ $externalSecret.secret }}
+    {{- if $externalSecret.template }}
     template:
-      data: {{- tpl .template $ | nindent 8 -}}
+      data: {{- tpl $externalSecret.template $ | nindent 8 -}}
     {{- end }}
-  {{- if .path }}
+  {{- if $externalSecret.path }}
   dataFrom:
     - extract:
-        key: {{ .path }}
+        key: {{ $externalSecret.path }}
   {{- end }}
-  {{- if .properties }}
+  {{- if $externalSecret.properties }}
   data:
-    {{- range .properties }}
+    {{- range $externalSecret.properties }}
     - secretKey: {{ .name }}
       remoteRef:
         key: {{ .sourceKey }}

--- a/ndustrial/nio-api/Chart.yaml
+++ b/ndustrial/nio-api/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 1.0.5
-appVersion: 1.0.5
+version: 1.0.6
+appVersion: 1.0.6

--- a/ndustrial/statefulset/Chart.yaml
+++ b/ndustrial/statefulset/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.37
-appVersion: 0.1.37
+version: 0.1.38
+appVersion: 0.1.38

--- a/ndustrial/statefulset/templates/externalsecrets.yaml
+++ b/ndustrial/statefulset/templates/externalsecrets.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.externalSecrets }}
 {{- range .Values.externalSecrets }}
-{{- if .path }}
-{{- $_ := set . "secret" (default (printf "%s" .path | replace "/" "-" | trunc 63) .secret) }}
+{{- $externalSecret := merge (dict "template" .template) (fromYaml (tpl (toYaml (omit . "template" )) $)) -}}
+{{- if $externalSecret.path }}
+{{- $_ := set $externalSecret "secret" (default (printf "%s" $externalSecret.path | replace "/" "-" | trunc 63) $externalSecret.secret) }}
 {{- else }}
-{{- $_ := set . "secret" (required "A secret is required when not passing path." .secret) }}
-{{- $_ := set . "properties" (required "A property list is required when not passing path." .properties) }}
+{{- $_ := set $externalSecret "secret" (required "A secret is required when not passing path." $externalSecret.secret) }}
+{{- $_ := set $externalSecret "properties" (required "A property list is required when not passing path." $externalSecret.properties) }}
 {{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .secret }}
+  name: {{ $externalSecret.secret }}
   labels: {{- include "nio-common.labels.standard" $ | nindent 4 }}
     ndustrial.io/component: statefulset
     {{- if $.Values.labels }}
@@ -21,22 +22,22 @@ metadata:
 spec:
   refreshInterval: "5m"
   secretStoreRef:
-    name: {{ default "vault-backend" .provider }}
-    kind: {{ default "ClusterSecretStore" .storeKind }}
+    name: {{ default "vault-backend" $externalSecret.provider }}
+    kind: {{ default "ClusterSecretStore" $externalSecret.storeKind }}
   target:
-    name: {{ .secret }}
-    {{- if .template }}
+    name: {{ $externalSecret.secret }}
+    {{- if $externalSecret.template }}
     template:
-      data: {{- tpl .template $ | nindent 8 -}}
+      data: {{- tpl $externalSecret.template $ | nindent 8 -}}
     {{- end }}
-  {{- if .path }}
+  {{- if $externalSecret.path }}
   dataFrom:
     - extract:
-        key: {{ .path }}
+        key: {{ $externalSecret.path }}
   {{- end }}
-  {{- if .properties }}
+  {{- if $externalSecret.properties }}
   data:
-    {{- range .properties }}
+    {{- range $externalSecret.properties }}
     - secretKey: {{ .name }}
       remoteRef:
         key: {{ .sourceKey }}


### PR DESCRIPTION
Allows us to template an `externalSecret` item using declared values. I had to separate the `template` property before templating the full dict since it gets templated later on (sort of a strange behavior with how ExternalSecrets enables the templating to occur. See added example for usage.