### PR TITLE
fix: support complex extra env var map

### DIFF
--- a/examples/deployment/cert-manager.yml
+++ b/examples/deployment/cert-manager.yml
@@ -68,3 +68,11 @@ externalSecrets:
 tenant: test-tenant
 updateStrategy:
   type: Recreate
+
+extraEnvVarsMap:
+  TEST: value
+  TEST_SECRET:
+    valueFrom:
+      secretKeyRef:
+        name: my-custom-secret-name
+        key: test

--- a/ndustrial/cronjob/Chart.yaml
+++ b/ndustrial/cronjob/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.29
-appVersion: 0.1.29
+version: 0.1.30
+appVersion: 0.1.30

--- a/ndustrial/cronjob/templates/cronjob.yaml
+++ b/ndustrial/cronjob/templates/cronjob.yaml
@@ -125,7 +125,11 @@ spec:
                 {{- if .Values.extraEnvVarsMap }}
                 {{- range $key, $val := .Values.extraEnvVarsMap }}
                 - name: {{ $key }}
+                {{- if (kindIs "map" $val ) }}
+                {{- include "nio-common.tplvalues.render" (dict "value" $val "context" $) | nindent 18 }}
+                {{- else }}
                   value: {{ include "nio-common.tplvalues.render" (dict "value" $val "context" $) | quote }}
+                {{- end }}
                 {{- end }}
                 {{- end }}
                 {{- if .Values.datadog }}

--- a/ndustrial/cronjob/values.yaml
+++ b/ndustrial/cronjob/values.yaml
@@ -162,10 +162,15 @@ shareProcessNamespace: false
 ##
 extraEnvVars: []
 
-## @param extraEnvVarsMap Add extra environment variables to the Deployment container
+## @param extraEnvVarsMap Add extra environment variables to the Deployment container. Can be a single string or a valid environment mapping
 ## E.g:
 ## extraEnvVarsMap:
 ##   FOO: "bar"
+##   FOO_SECRET:
+##     valueFrom:
+##       secretKeyRef:
+##         name: secret
+##         key: test
 ##
 extraEnvVarsMap: {}
 

--- a/ndustrial/daemonset/Chart.yaml
+++ b/ndustrial/daemonset/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.7
-appVersion: 0.1.7
+version: 0.1.8
+appVersion: 0.1.8

--- a/ndustrial/daemonset/templates/daemonset.yaml
+++ b/ndustrial/daemonset/templates/daemonset.yaml
@@ -90,7 +90,11 @@ spec:
             {{- if .Values.extraEnvVarsMap }}
             {{- range $key, $val := .Values.extraEnvVarsMap }}
             - name: {{ $key }}
+            {{- if (kindIs "map" $val ) }}
+            {{- include "nio-common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+            {{- else }}
               value: {{ include "nio-common.tplvalues.render" (dict "value" $val "context" $) | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
             - name: POD_NAMESPACE

--- a/ndustrial/daemonset/values.yaml
+++ b/ndustrial/daemonset/values.yaml
@@ -340,6 +340,11 @@ extraEnvVars: []
 ## E.g:
 ## extraEnvVarsMap:
 ##   FOO: "bar"
+##   FOO_SECRET:
+##     valueFrom:
+##       secretKeyRef:
+##         name: secret
+##         key: test
 ##
 extraEnvVarsMap: {}
 

--- a/ndustrial/deployment/Chart.yaml
+++ b/ndustrial/deployment/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.63
-appVersion: 0.1.63
+version: 0.1.64
+appVersion: 0.1.64

--- a/ndustrial/deployment/templates/deployment.yaml
+++ b/ndustrial/deployment/templates/deployment.yaml
@@ -104,7 +104,11 @@ spec:
             {{- if .Values.extraEnvVarsMap }}
             {{- range $key, $val := .Values.extraEnvVarsMap }}
             - name: {{ $key }}
+            {{- if (kindIs "map" $val ) }}
+            {{- include "nio-common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+            {{- else }}
               value: {{ include "nio-common.tplvalues.render" (dict "value" $val "context" $) | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
             - name: POD_NAMESPACE

--- a/ndustrial/deployment/values.yaml
+++ b/ndustrial/deployment/values.yaml
@@ -389,6 +389,11 @@ extraEnvVars: []
 ## E.g:
 ## extraEnvVarsMap:
 ##   FOO: "bar"
+##   FOO_SECRET:
+##     valueFrom:
+##       secretKeyRef:
+##         name: secret
+##         key: test
 ##
 extraEnvVarsMap: {}
 

--- a/ndustrial/nio-api/Chart.yaml
+++ b/ndustrial/nio-api/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 1.0.11
-appVersion: 1.0.11
+version: 1.0.12
+appVersion: 1.0.12

--- a/ndustrial/nio-api/values.yaml
+++ b/ndustrial/nio-api/values.yaml
@@ -365,6 +365,11 @@ extraEnvVars: []
 ## E.g:
 ## extraEnvVarsMap:
 ##   FOO: "bar"
+##   FOO_SECRET:
+##     valueFrom:
+##       secretKeyRef:
+##         name: secret
+##         key: test
 ##
 extraEnvVarsMap: {}
 ## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars

--- a/ndustrial/statefulset/Chart.yaml
+++ b/ndustrial/statefulset/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.39
-appVersion: 0.1.39
+version: 0.1.40
+appVersion: 0.1.40

--- a/ndustrial/statefulset/templates/statefuleset.yaml
+++ b/ndustrial/statefulset/templates/statefuleset.yaml
@@ -105,7 +105,11 @@ spec:
             {{- if .Values.extraEnvVarsMap }}
             {{- range $key, $val := .Values.extraEnvVarsMap }}
             - name: {{ $key }}
+            {{- if (kindIs "map" $val ) }}
+            {{- include "nio-common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+            {{- else }}
               value: {{ include "nio-common.tplvalues.render" (dict "value" $val "context" $) | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if .Values.datadog }}

--- a/ndustrial/statefulset/values.yaml
+++ b/ndustrial/statefulset/values.yaml
@@ -363,6 +363,11 @@ extraEnvVars: []
 ## E.g:
 ## extraEnvVarsMap:
 ##   FOO: "bar"
+##   FOO_SECRET:
+##     valueFrom:
+##       secretKeyRef:
+##         name: secret
+##         key: test
 ##
 extraEnvVarsMap: {}
 


### PR DESCRIPTION
There are currently two main ways to embed environment variables - `extraEnvVars` and `extraEnvVarsMap`. The former is a 1:1 mapping of the environment variable structure allowing for complex values (such as a value from a secret). The latter is a map of key/value where the value is only strings.

This PR allows the map method to support complex values.

The main reason for this is that you cannot combine lists via helm value merging functionality. Example:

```yaml
# values.yaml

extraEnvVars:
  - name: A_VALUE
    value: "hello"
  - name: TEST
    value: "foo"

# values-prod.yaml
extraEnvVars:
  - name: TEST
    value: "bar"
```

When running `helm template . -f values.yaml -f values-prod.yaml`, the env var `A_VALUE` will be excluded as the merging of the two lists resolves by taking the latter in full, since this is no way to determine which overrides the other.

When using a map, however:
```yaml
# values.yaml

extraEnvVarsMap:
  - A_VALUE: "hello"
  - TEST: "foo"

# values-prod.yaml
extraEnvVarsMap:
  - TEST: "bar"
```

The merged output will be:

```yaml
extraEnvVarsMap:
  - A_VALUE: "hello"
  - TEST: "bar"
```
