### PR TITLE
feat: support templated host names

### DIFF
--- a/examples/deployment/cert-manager.yml
+++ b/examples/deployment/cert-manager.yml
@@ -25,7 +25,10 @@ ingress:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
   tls: true
-  hostname: cert-manager-example.staging.pizzandustrial.com
+  hostname: "{{ .Values.ndustrial.name }}.staging.pizzandustrial.com"
+  extraHosts:
+    - name: "test.staging.pizzandustrial.com"
+    - name: "{{ .Values.ndustrial.name }}-test.staging.pizzandustrial.com"
 image:
   registry: docker.ops.ndustrial.io
   repository: library/nginx

--- a/ndustrial/daemonset/Chart.yaml
+++ b/ndustrial/daemonset/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.8
-appVersion: 0.1.8
+version: 0.1.9
+appVersion: 0.1.9

--- a/ndustrial/daemonset/templates/ingress.yaml
+++ b/ndustrial/daemonset/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -40,7 +40,7 @@ spec:
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     {{- if and (hasKey . "tlsOnly") (not .tlsOnly) }}
-    - host: {{ .name | quote }}
+    - host: {{ include "nio-common.tplvalues.render" ( dict "value" .name "context" $ ) | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
@@ -54,11 +54,11 @@ spec:
   tls:
     {{- if and .Values.ingress.tls (or .Values.ingress.certManager .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname | quote }}
+        - {{ include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) | quote }}
         {{- range .Values.ingress.extraHosts }}
-        - {{ .name | quote }}
+        - {{ include "nio-common.tplvalues.render" ( dict "value" .name "context" $ ) | quote }}
         {{- end }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" (include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ )) }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "nio-common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}

--- a/ndustrial/deployment/Chart.yaml
+++ b/ndustrial/deployment/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.65
-appVersion: 0.1.65
+version: 0.1.66
+appVersion: 0.1.66

--- a/ndustrial/deployment/templates/ingress.yaml
+++ b/ndustrial/deployment/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -40,7 +40,7 @@ spec:
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     {{- if and (hasKey . "tlsOnly") (not .tlsOnly) }}
-    - host: {{ .name | quote }}
+    - host: {{ include "nio-common.tplvalues.render" ( dict "value" .name "context" $ ) | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
@@ -54,11 +54,11 @@ spec:
   tls:
     {{- if and .Values.ingress.tls (or .Values.ingress.certManager .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname | quote }}
+        - {{ include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) | quote }}
         {{- range .Values.ingress.extraHosts }}
-        - {{ .name | quote }}
+        - {{ include "nio-common.tplvalues.render" ( dict "value" .name "context" $ ) | quote }}
         {{- end }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" (include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ )) }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "nio-common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}

--- a/ndustrial/nio-api/Chart.yaml
+++ b/ndustrial/nio-api/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 1.0.12
-appVersion: 1.0.12
+version: 1.0.13
+appVersion: 1.0.13

--- a/ndustrial/statefulset/Chart.yaml
+++ b/ndustrial/statefulset/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   - email: devops@ndustrial.io
     name: DevOps
 # Please make sure that version and appVersion are always the same.
-version: 0.1.40
-appVersion: 0.1.40
+version: 0.1.41
+appVersion: 0.1.41

--- a/ndustrial/statefulset/templates/ingress.yaml
+++ b/ndustrial/statefulset/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -40,7 +40,7 @@ spec:
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     {{- if and (hasKey . "tlsOnly") (not .tlsOnly) }}
-    - host: {{ .name | quote }}
+    - host: {{ include "nio-common.tplvalues.render" ( dict "value" .name "context" $ ) | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
@@ -54,11 +54,11 @@ spec:
   tls:
     {{- if and .Values.ingress.tls (or .Values.ingress.certManager .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname | quote }}
+        - {{ include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) | quote }}
         {{- range .Values.ingress.extraHosts }}
-        - {{ .name | quote }}
+        - {{ include "nio-common.tplvalues.render" ( dict "value" .name "context" $ ) | quote }}
         {{- end }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" (include "nio-common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ )) }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "nio-common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}


### PR DESCRIPTION
The example at `examples/deployment/cert-manager.yml` creates:

```yaml
# Source: deployment/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-deployment
  namespace: "edge-prod"
  labels:
    app.kubernetes.io/name: deployment
    helm.sh/chart: deployment-0.1.65
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    
    ndustrial.io/app: cert-manager-example
    backstage.io/kubernetes-id: cert-manager-example
    ndustrial.io/organization.slug: ndustrial
    ndustrial.io/owner: helm
    ndustrial.io/project.slug: example
    ndustrial.io/project.type: example
    ndustrial.io/version: latest
    ndustrial.io/managed-by: helm
    ndustrial.io/env: staging
    ndustrial.io/repo: cert-manager-example
    
    tags.datadoghq.com/env: staging
    tags.datadoghq.com/version: 0.0.1
    tags.datadoghq.com/service: cert-manager-example
  annotations:
    kubernetes.io/tls-acme: "true"
    cert-manager.io/cluster-issuer: letsencrypt-staging
    kubernetes.io/ingress.class: nginx-global
    nginx.ingress.kubernetes.io/configuration-snippet: |
      more_set_headers "X-Robots-Tag: noindex";
spec:
  rules:
    - host: cert-manager-example.staging.pizzandustrial.com
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name: release-name-deployment
                port:
                  name: http
  tls:
    - hosts:
        - "cert-manager-example.staging.pizzandustrial.com"
        - "test.staging.pizzandustrial.com"
        - "cert-manager-example-test.staging.pizzandustrial.com"
      secretName: cert-manager-example.staging.pizzandustrial.com-tls
```